### PR TITLE
bug fix: Windows downloads saves to exact filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ $URL1="https://storage.googleapis.com/$BUCKET/$BLOCKCHAIN_DATE/blockindexes.bin"
 $URL2="https://storage.googleapis.com/$BUCKET/$BLOCKCHAIN_DATE/blocks.bin"
 
 #DO THE ACTUAL BLOCKCHAIN DOWNLOAD
-curl $URL1
-curl $URL2
+curl $URL1 -OutFile blockindexes.bin
+curl $URL2 -OutFile blocks.bin
 
 echo "The Blockchain is now Downloaded!"
 echo "Please open the Bytecoin GUI App and allow it up to an hour to officially load up and read the entire blockchain"


### PR DESCRIPTION
Fixing issue #1

Added in the Exact File names to explicitly state the file names to save the blockchain indexes and blocks files in the correct places.

Before the files were downloaded into the computer's ram only and output to the display of random symbols as it is a Binary File. Now the Binary files are immediately saved to the files.